### PR TITLE
fix PeerDiscovery#peers failure in regtest mode.

### DIFF
--- a/lib/bitcoin/chain_params.rb
+++ b/lib/bitcoin/chain_params.rb
@@ -23,6 +23,7 @@ module Bitcoin
     attr_reader :bip34_height
     attr_reader :proof_of_work_limit
     attr_reader :dns_seeds
+    attr_reader :connect
     attr_reader :genesis
 
     # mainnet genesis

--- a/lib/bitcoin/chainparams/mainnet.yml
+++ b/lib/bitcoin/chainparams/mainnet.yml
@@ -22,6 +22,7 @@ dns_seeds:
   - "dnsseed.bitcoin.dashjr.org"
   - "seed.bitcoinstats.com"
   - "seed.bitcoin.jonasschnelli.ch"
+connect:
 genesis:
   hash: "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
   merkle_root: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"

--- a/lib/bitcoin/chainparams/regtest.yml
+++ b/lib/bitcoin/chainparams/regtest.yml
@@ -18,6 +18,7 @@ bip34_height: 0
 genesis_hash: "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
 proof_of_work_limit: 0x207fffff
 dns_seeds:
+connect:
 genesis:
   hash: "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
   merkle_root: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"

--- a/lib/bitcoin/chainparams/testnet.yml
+++ b/lib/bitcoin/chainparams/testnet.yml
@@ -22,6 +22,7 @@ dns_seeds:
   - "seed.tbtc.petertodd.org"
   - "testnet-seed.bluematt.me"
   - "testnet-seed.bitcoin.schildbach.de"
+connect:
 genesis:
   hash: "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
   merkle_root: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"

--- a/lib/bitcoin/network/peer_discovery.rb
+++ b/lib/bitcoin/network/peer_discovery.rb
@@ -12,14 +12,22 @@ module Bitcoin
       # get peer addresses, from DNS seeds.
       def peers
         # TODO add find from previous connected peer at first.
-        find_from_dns_seeds
+        find_from_dns_seeds + seeds
       end
 
       private
 
+      def dns_seeds
+        Bitcoin.chain_params.dns_seeds || []
+      end
+
+      def seeds
+        Bitcoin.chain_params.connect || []
+      end
+
       def find_from_dns_seeds
         logger.debug 'discover peer address from DNS seeds.'
-        Bitcoin.chain_params.dns_seeds.map {|seed|
+        dns_seeds.map { |seed|
           begin
             Socket.getaddrinfo(seed, Bitcoin.chain_params.default_port).map{|a|a[2]}.uniq
           rescue SocketError => e
@@ -28,8 +36,6 @@ module Bitcoin
           end
         }.flatten.compact
       end
-
     end
-
   end
 end

--- a/spec/bitcoin/network/peer_discovery_spec.rb
+++ b/spec/bitcoin/network/peer_discovery_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Bitcoin::Network::PeerDiscovery do
+
+  describe '#peers' do
+    let(:dns_seeds) { [] }
+    let(:connect) { [] }
+    subject {
+      peer_discovery = Bitcoin::Network::PeerDiscovery.new
+      allow(peer_discovery).to receive(:dns_seeds).and_return(dns_seeds)
+      allow(peer_discovery).to receive(:seeds).and_return(connect)
+      peer_discovery
+    }
+    context 'dns_seeds is empty' do
+      context 'connect nodes is empty' do
+        it 'should be empty' do
+          expect(subject.peers).to eq []
+        end
+      end
+      context 'one connect node exists' do
+        let(:connect) { ['123.123.123.123'] }
+        it 'should return one node' do
+          expect(subject.peers).to eq ['123.123.123.123']
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
regtestで起動するとPeerDiscovery#peersで落ちる問題に対応しました。
chain_paramsのdns_seedsが定義されていない場合は、connectで定義されたノードに直接アクセスするようにしています。