### PR TITLE
Fix peer discovery process when no dns seeds

### DIFF
--- a/bitcoinrb.gemspec
+++ b/bitcoinrb.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'leveldb-ruby'
   spec.add_runtime_dependency 'eventmachine_httpserver'
   spec.add_runtime_dependency 'rest-client'
-  spec.add_runtime_dependency 'inifile'
+  spec.add_runtime_dependency 'iniparse'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/bitcoin/network/peer_discovery.rb
+++ b/lib/bitcoin/network/peer_discovery.rb
@@ -23,12 +23,11 @@ module Bitcoin
       end
 
       def seeds
-        puts configuration.conf
         [*configuration.conf[:connect]]
       end
 
       def find_from_dns_seeds
-        logger.info 'discover peer address from DNS seeds.'
+        logger.debug 'discover peer address from DNS seeds.'
         dns_seeds.map { |seed|
           begin
             Socket.getaddrinfo(seed, Bitcoin.chain_params.default_port).map{|a|a[2]}.uniq

--- a/lib/bitcoin/network/pool.rb
+++ b/lib/bitcoin/network/pool.rb
@@ -33,11 +33,10 @@ module Bitcoin
       # connecting other peers and begin network activity.
       def start
         raise 'Cannot start a peer pool twice.' if started
-        logger.info 'Start connecting other pears.'
+        logger.debug 'Start connecting other pears.'
         addr_list = peer_discovery.peers
         port = Bitcoin.chain_params.default_port
         EM::Iterator.new(addr_list, Bitcoin::PARALLEL_THREAD).each do |ip, iter|
-          logger.info "connecting to ... #{ip}"
           if pending_peers.size < MAX_OUTBOUND_CONNECTIONS
             peer = Peer.new(ip, port, self)
             pending_peers << peer
@@ -50,7 +49,7 @@ module Bitcoin
 
       # detect new peer connection.
       def handle_new_peer(peer)
-        logger.info "connected new peer #{peer.addr}."
+        logger.debug "connected new peer #{peer.addr}."
         peer.id = allocate_peer_id
         unless peers.find(&:primary?)
           peer.primary = true

--- a/lib/bitcoin/node/configuration.rb
+++ b/lib/bitcoin/node/configuration.rb
@@ -1,4 +1,4 @@
-require 'inifile'
+require 'iniparse'
 
 module Bitcoin
   module Node
@@ -8,7 +8,12 @@ module Bitcoin
 
       def initialize(opts = {})
         # TODO apply configuration file.
-        @conf = IniFile.load("#{Bitcoin.base_dir}/bitcoinrb.conf").to_h
+        begin
+          ini_file = IniParse.parse(File.read("#{Bitcoin.base_dir}/bitcoinrb.conf"))
+          @conf = Hash[ ini_file.to_h['__anonymous__'].map{|k,v| [k.to_sym, v] } ]
+        rescue => e
+          @conf = {}
+        end
         @conf.merge!(opts)
         @conf[:network] = :mainnet unless @conf[:network]
         Bitcoin.chain_params = @conf[:network]

--- a/lib/bitcoin/node/configuration.rb
+++ b/lib/bitcoin/node/configuration.rb
@@ -8,8 +8,8 @@ module Bitcoin
 
       def initialize(opts = {})
         # TODO apply configuration file.
-        opt[:network] = :mainnet unless opt[:network]
-        Bitcoin.chain_params = opt[:network]
+        opts[:network] = :mainnet unless opts[:network]
+        Bitcoin.chain_params = opts[:network]
 
         begin
           ini_file = IniParse.parse(File.read("#{Bitcoin.base_dir}/bitcoinrb.conf"))

--- a/lib/bitcoin/node/configuration.rb
+++ b/lib/bitcoin/node/configuration.rb
@@ -8,6 +8,9 @@ module Bitcoin
 
       def initialize(opts = {})
         # TODO apply configuration file.
+        opt[:network] = :mainnet unless opt[:network]
+        Bitcoin.chain_params = opt[:network]
+
         begin
           ini_file = IniParse.parse(File.read("#{Bitcoin.base_dir}/bitcoinrb.conf"))
           @conf = Hash[ ini_file.to_h['__anonymous__'].map{|k,v| [k.to_sym, v] } ]
@@ -15,8 +18,6 @@ module Bitcoin
           @conf = {}
         end
         @conf.merge!(opts)
-        @conf[:network] = :mainnet unless @conf[:network]
-        Bitcoin.chain_params = @conf[:network]
       end
 
       def host

--- a/lib/bitcoin/node/spv.rb
+++ b/lib/bitcoin/node/spv.rb
@@ -13,10 +13,10 @@ module Bitcoin
 
       def initialize(configuration)
         @chain = Bitcoin::Store::SPVChain.new
-        @pool = Bitcoin::Network::Pool.new(@chain)
+        @configuration = configuration
+        @pool = Bitcoin::Network::Pool.new(@chain, @configuration)
         @logger = Bitcoin::Logger.create(:debug)
         @running = false
-        @configuration = configuration
       end
 
       # open the node.

--- a/lib/bitcoin/store/db/level_db.rb
+++ b/lib/bitcoin/store/db/level_db.rb
@@ -66,6 +66,10 @@ module Bitcoin
           end
         end
 
+        def close
+          db.close
+        end
+
         private
 
         # generate height key

--- a/spec/bitcoin/network/message_handler_spec.rb
+++ b/spec/bitcoin/network/message_handler_spec.rb
@@ -4,12 +4,14 @@ describe Bitcoin::Network::MessageHandler do
 
   class Handler
     include Bitcoin::Network::MessageHandler
-    attr_reader :logger, :peer, :sendheaders
+    attr_reader :logger, :peer, :sendheaders, :chain
     def initialize
       @message = ''
       @logger = Logger.new(STDOUT)
-      @peer = Bitcoin::Network::Peer.new('127.0.0.1', 18332, Bitcoin::Network::Pool.new(create_test_chain))
-      @sendheaders= false
+      configuration = Bitcoin::Node::Configuration.new(network: :testnet)
+      @chain = create_test_chain
+      @peer = Bitcoin::Network::Peer.new('127.0.0.1', 18332, Bitcoin::Network::Pool.new(@chain, configuration))
+      @sendheaders = false
     end
 
     def addr
@@ -18,9 +20,9 @@ describe Bitcoin::Network::MessageHandler do
   end
 
   subject {Handler.new}
+  after { subject.chain.db.close }
 
   describe 'handle message' do
-
     context 'invalid header magic' do
       it 'raise message error' do # mainnet magic
         expect(subject).to receive(:close).once

--- a/spec/bitcoin/network/peer_discovery_spec.rb
+++ b/spec/bitcoin/network/peer_discovery_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe Bitcoin::Network::PeerDiscovery do
+
+  describe '#peers' do
+    let(:dns_seeds) { [] }
+    let(:configuration) { Bitcoin::Node::Configuration.new }
+    subject {
+      peer_discovery = Bitcoin::Network::PeerDiscovery.new(configuration)
+      allow(peer_discovery).to receive(:dns_seeds).and_return(dns_seeds)
+      peer_discovery
+    }
+    context 'dns_seeds is empty' do
+      context 'connect nodes is empty' do
+        it 'should be empty' do
+          expect(subject.peers).to eq []
+        end
+      end
+      context 'one connect node exists' do
+        let(:configuration) { Bitcoin::Node::Configuration.new(connect:'123.123.123.123') }
+        it 'should return one node' do
+          expect(subject.peers).to eq ['123.123.123.123']
+        end
+      end
+      context 'multiple connect nodes exist' do
+        let(:configuration) { Bitcoin::Node::Configuration.new(connect:['123.123.123.123', '123.123.123.124', '123.123.123.125']) }
+        it 'should return multiple node' do
+          expect(subject.peers).to eq ['123.123.123.123', '123.123.123.124', '123.123.123.125']
+        end
+      end
+      context 'duplidate nodes exist' do
+        let(:configuration) { Bitcoin::Node::Configuration.new(connect:['123.123.123.123', '123.123.123.123']) }
+        it 'should return only unique node' do
+          expect(subject.peers).to eq ['123.123.123.123']
+        end
+      end
+    end
+  end
+end

--- a/spec/bitcoin/network/peer_spec.rb
+++ b/spec/bitcoin/network/peer_spec.rb
@@ -6,13 +6,16 @@ describe Bitcoin::Network::Peer do
     attr_accessor :version, :sendheaders, :fee_rate
   end
 
+  let(:chain) { create_test_chain }
   subject {
     chain_mock = double('chain mock')
-    peer = Bitcoin::Network::Peer.new('210.196.254.100', 18333, Bitcoin::Network::Pool.new(create_test_chain))
+    configuration = Bitcoin::Node::Configuration.new(network: :testnet)
+    peer = Bitcoin::Network::Peer.new('210.196.254.100', 18333, Bitcoin::Network::Pool.new(chain, configuration))
     peer.conn = ConnectionMock.new
     allow(peer).to receive(:chain).and_return(chain_mock)
     peer
   }
+  after { chain.db.close }
 
   describe '#support_witness?' do
     context 'before handshake' do

--- a/spec/bitcoin/network/pool_spec.rb
+++ b/spec/bitcoin/network/pool_spec.rb
@@ -3,8 +3,10 @@ require 'spec_helper'
 describe Bitcoin::Network::Pool do
 
   describe '#allocate_peer_id' do
+    let (:chain) { create_test_chain }
     subject {
-      pool = Bitcoin::Network::Pool.new(create_test_chain)
+      configuration = Bitcoin::Node::Configuration.new
+      pool = Bitcoin::Network::Pool.new(chain, configuration)
       peer1 = Bitcoin::Network::Peer.new('192.168.0.1', 18333, pool)
       peer2 = Bitcoin::Network::Peer.new('192.168.0.2', 18333, pool)
       peer3 = Bitcoin::Network::Peer.new('192.168.0.3', 18333, pool)
@@ -16,6 +18,8 @@ describe Bitcoin::Network::Pool do
       pool.handle_new_peer(peer3)
       pool
     }
+    after { chain.db.close }
+
     it 'should allocate peer id' do
       expect(subject.peers.size).to eq(3)
       expect(subject.peers[0].id).to eq(0)

--- a/spec/bitcoin/rpc/request_handler_spec.rb
+++ b/spec/bitcoin/rpc/request_handler_spec.rb
@@ -10,12 +10,14 @@ describe Bitcoin::RPC::RequestHandler do
     end
   end
 
+  let(:chain) { load_chain_mock }
   subject {
     node_mock = double('node mock')
-    allow(node_mock).to receive(:chain).and_return(load_chain_mock)
+    allow(node_mock).to receive(:chain).and_return(chain)
     allow(node_mock).to receive(:pool).and_return(load_pool_mock(node_mock.chain))
     HandlerMock.new(node_mock)
   }
+  after { chain.db.close }
 
   describe '#getblockchaininfo' do
     it 'should return chain info' do
@@ -112,7 +114,8 @@ describe Bitcoin::RPC::RequestHandler do
     ))
     allow(conn2).to receive(:version).and_return(Bitcoin::Message::Version.new)
 
-    pool = Bitcoin::Network::Pool.new(chain)
+    configuration = Bitcoin::Node::Configuration.new(network: :testnet)
+    pool = Bitcoin::Network::Pool.new(chain, configuration)
 
     peer1 =Bitcoin::Network::Peer.new('192.168.0.1', 18333, pool)
     peer1.id = 1

--- a/spec/bitcoin/store/spv_chain_spec.rb
+++ b/spec/bitcoin/store/spv_chain_spec.rb
@@ -4,9 +4,9 @@ require 'fileutils'
 
 describe Bitcoin::Store::SPVChain do
 
-  subject {
-    create_test_chain
-  }
+  let (:chain) { create_test_chain }
+  subject { chain }
+  after { chain.db.close }
 
   describe '#append_header' do
     context 'correct header' do


### PR DESCRIPTION
regtestで起動するとPeerDiscovery#peersで落ちる問題に対応しました。

- chain_paramsのdns_seedsが定義されていない場合は、bitcoinrb.confで定義されたノードに直接アクセスするようにしています。
- bitcoinrb.confの読み込み時に複数のconnectを指定された場合にIniFileによる読み込みでは値が上書きされて、1つのノードにしか有効にならなかったので、inifileの代わりにiniparse(https://github.com/antw/iniparse/)を使用するようにしました。
- ConfigurationのコンストラクタでBitcoin.chain_paramsを設定していましたが、Bitcoin.base_dir以前に設定をしなければ対応するbitcoinrb.confを読み込まないようになっていたので、修正しました。