### PR TITLE
Payload#to_payload supports binary metadata.

### DIFF
--- a/lib/openassets/payload.rb
+++ b/lib/openassets/payload.rb
@@ -40,7 +40,7 @@ module OpenAssets
       payload << MARKER
       payload << VERSION
       payload << Bitcoin.pack_var_int(quantities.size) << quantities.map{|q| LEB128.encode_unsigned(q).read }.join
-      payload << Bitcoin.pack_var_int(metadata.length) << metadata.bytes.map{|b|b.to_s(16)}.join.htb
+      payload << Bitcoin.pack_var_int(metadata.length) << metadata.bytes.map{|b| sprintf("%02x", b)}.join.htb
       payload
     end
 

--- a/spec/openassets/payload_spec.rb
+++ b/spec/openassets/payload_spec.rb
@@ -17,10 +17,19 @@ describe OpenAssets::Payload do
 
   describe '#to_payload' do
     subject {
-      OpenAssets::Payload.new([100, 0, 123], 'u=https://cpr.sm/5YgSU1Pg-q').to_payload
+      OpenAssets::Payload.new([100, 0, 123], metadata).to_payload
     }
-    it 'generate payload' do
-      expect(subject.bth).to eq('4f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71')
+    context 'metadata is asset definition url' do
+      let(:metadata) { 'u=https://cpr.sm/5YgSU1Pg-q' }
+      it 'generate payload' do
+        expect(subject.bth).to eq('4f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71')
+      end
+    end
+    context 'metadata is binary string' do
+      let(:metadata) { "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f" }
+      it 'generate payload' do
+        expect(subject.bth).to eq('4f4101000364007b10000102030405060708090a0b0c0d0e0f')
+      end
     end
   end
 


### PR DESCRIPTION
metadataに0x01, 0x02,...などのバイナリーを設定した時にto_payloadで0パディングされない問題に対応しました。

参照: https://github.com/haw-itn/openassets-ruby/pull/19