### PR TITLE
Handshake must be established only after verack message is sent and received

### DIFF
--- a/lib/bitcoin/network/message_handler.rb
+++ b/lib/bitcoin/network/message_handler.rb
@@ -107,6 +107,7 @@ module Bitcoin
       end
 
       def handshake_done
+        return unless @incomming_handshake && @outgoing_handshake
         logger.info 'handshake finished.'
         @connected = true
         post_handshake
@@ -116,10 +117,13 @@ module Bitcoin
         logger.info("receive version message. #{version.build_json}")
         @version = version
         send_message(Bitcoin::Message::VerAck.new)
+        @incomming_handshake = true
+        handshake_done
       end
 
       def on_ver_ack
         logger.info('receive verack message.')
+        @outgoing_handshake = true
         handshake_done
       end
 


### PR DESCRIPTION
BitcoinCoreのフルノードは、VerAck受信前にsendheadersなどのメッセージを受信した場合、エラーとして処理している。
bitcoinrbではノードへVerAckを送信する前にハンドシェイク完了する処理を行い、続けてsendheadersメッセージを送信していた。このため、タイミングによってはノード側でエラーとなっていた。

VerAckメッセージを送受信が完了した時点でハンドシェイクの処理を続行するように修正しました。
