### PR TITLE
Features/bloom filter

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -145,6 +145,7 @@ module Bitcoin
     end
 
     def to_h
+      return self if self.is_a?(String)
       instance_variables.inject({}) do |result, var|
         key = var.to_s
         key.slice!(0) if key.start_with?('@')

--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -42,6 +42,7 @@ module Bitcoin
   autoload :Store, 'bitcoin/store'
   autoload :RPC, 'bitcoin/rpc'
   autoload :Wallet, 'bitcoin/wallet'
+  autoload :BloomFilter, 'bitcoin/bloom_filter'
 
   require_relative 'bitcoin/constants'
 

--- a/lib/bitcoin/bloom_filter.rb
+++ b/lib/bitcoin/bloom_filter.rb
@@ -1,0 +1,69 @@
+require "murmurhash3"
+module Bitcoin
+  class BloomFilter
+    LN2_SQUARED = 0.4804530139182014246671025263266649717305529515945455 # log(2) ** 2
+    LN2 = 0.6931471805599453094172321214581765680755001343602552 # log(2)
+
+    MAX_BLOOM_FILTER_SIZE = 36_000 # bytes
+    MAX_HASH_FUNCS = 50
+
+    # @param [Integer] elements_length the number of elements
+    # @param [Float] fp_rate the false positive rate chosen by the client
+    # @param [Integer] tweak A random value to add to the seed value in the hash function used by the bloom filter
+    def initialize(elements_length, fp_rate, tweak=0)
+      # The size S of the filter in bytes is given by (-1 / pow(log(2), 2) * N * log(P)) / 8
+      len = [(-elements_length * Math.log(fp_rate) / (LN2_SQUARED * 8)).to_i, MAX_BLOOM_FILTER_SIZE].min
+      @filter = Array.new(len, 0)
+      # The number of hash functions required is given by S * 8 / N * log(2)
+      @hash_funcs = [(@filter.size * 8 * LN2 / elements_length).to_i, MAX_HASH_FUNCS].min
+      @tweak = tweak
+    end
+
+    # @param [String] data The data element to add to the current filter.
+    def add(data)
+      return if full?
+      @hash_funcs.times do |i|
+        hash = to_hash(data, i)
+        set_bit(hash)
+      end
+    end
+
+    # Returns true if the given data matches the filter
+    # @param [String] data The data to check the current filter
+    # @return [Boolean] true if the given data matches the filter
+    def contains?(data)
+      return true if full?
+      @hash_funcs.times do |i|
+        hash = to_hash(data, i)
+        return false unless check_bit(hash)
+      end
+      true
+    end
+
+    def clear
+      @filter.fill(0)
+      @full = false
+    end
+
+    def to_a
+      @filter
+    end
+
+    private
+    def to_hash(data, i)
+      MurmurHash3::V32.str_hash(data, (i * 0xfba4c795 + @tweak) & 0xffffffff)  % (@filter.length * 8)
+    end
+
+    def set_bit(data)
+      @filter[data >> 3] |= (1 << (7 & data))
+    end
+
+    def check_bit(data)
+      @filter[data >> 3] & (1 << (7 & data)) != 0
+    end
+
+    def full?
+      @full |= @filter.all? {|byte| byte == 0xff}
+    end
+  end
+end

--- a/lib/bitcoin/bloom_filter.rb
+++ b/lib/bitcoin/bloom_filter.rb
@@ -7,15 +7,17 @@ module Bitcoin
     MAX_BLOOM_FILTER_SIZE = 36_000 # bytes
     MAX_HASH_FUNCS = 50
 
+    attr_reader :hash_funcs, :tweak
+
     # @param [Integer] elements_length the number of elements
     # @param [Float] fp_rate the false positive rate chosen by the client
     # @param [Integer] tweak A random value to add to the seed value in the hash function used by the bloom filter
     def initialize(elements_length, fp_rate, tweak=0)
       # The size S of the filter in bytes is given by (-1 / pow(log(2), 2) * N * log(P)) / 8
-      len = [(-elements_length * Math.log(fp_rate) / (LN2_SQUARED * 8)).to_i, MAX_BLOOM_FILTER_SIZE].min
+      len = [[(-elements_length * Math.log(fp_rate) / (LN2_SQUARED * 8)).to_i, MAX_BLOOM_FILTER_SIZE].min, 1].max
       @filter = Array.new(len, 0)
       # The number of hash functions required is given by S * 8 / N * log(2)
-      @hash_funcs = [(@filter.size * 8 * LN2 / elements_length).to_i, MAX_HASH_FUNCS].min
+      @hash_funcs = [[(@filter.size * 8 * LN2 / elements_length).to_i, MAX_HASH_FUNCS].min, 1].max
       @tweak = tweak
     end
 

--- a/lib/bitcoin/message/version.rb
+++ b/lib/bitcoin/message/version.rb
@@ -27,8 +27,8 @@ module Bitcoin
         @nonce = SecureRandom.random_number(0xffffffffffffffff)
         @user_agent = Bitcoin::Message::USER_AGENT
         @start_height = 0
-        @relay = true
         opts.each { |k, v| send "#{k}=", v }
+        @relay = opts[:relay] || false
       end
 
       def self.parse_from_payload(payload)

--- a/lib/bitcoin/network/peer.rb
+++ b/lib/bitcoin/network/peer.rb
@@ -186,7 +186,28 @@ module Bitcoin
         conn.send_message(ping)
       end
 
-    end
+      # send filterload message.
+      def send_filter_load(bloom)
+        filter_load = Bitcoin::Message::FilterLoad.new(
+          bloom.to_a,
+          bloom.hash_funcs,
+          bloom.tweak,
+          Bitcoin::Message::FilterLoad::BLOOM_UPDATE_ALL
+        )
+        conn.send_message(filter_load)
+      end
 
+      # send filteradd message.
+      def send_filter_add(element)
+        filter_add = Bitcoin::Message::FilterAdd.new(element)
+        conn.send_message(filter_add)
+      end
+
+      # send filterclear message.
+      def send_filter_clear
+        filter_clear = Bitcoin::Message::FilterClear.new
+        conn.send_message(filter_clear)
+      end
+    end
   end
 end

--- a/lib/bitcoin/network/peer.rb
+++ b/lib/bitcoin/network/peer.rb
@@ -34,7 +34,7 @@ module Bitcoin
       attr_reader :chain
       attr_accessor :fee_rate
 
-      def initialize(host, port, pool)
+      def initialize(host, port, pool, configuration)
         @host = host
         @port = port
         @pool = pool
@@ -48,8 +48,9 @@ module Bitcoin
         @min_ping = -1
         @bytes_sent = 0
         @bytes_recv = 0
+        @relay = configuration.conf[:relay]
         current_height = @chain.latest_block.height
-        @local_version = Bitcoin::Message::Version.new(remote_addr: addr, start_height: current_height, relay: false)
+        @local_version = Bitcoin::Message::Version.new(remote_addr: addr, start_height: current_height, relay: @relay)
       end
 
       def connect

--- a/lib/bitcoin/network/pool.rb
+++ b/lib/bitcoin/network/pool.rb
@@ -26,6 +26,7 @@ module Bitcoin
         @max_outbound = MAX_OUTBOUND_CONNECTIONS
         @chain = chain
         @logger = Bitcoin::Logger.create(:debug)
+        @configuration = configuration
         @peer_discovery = PeerDiscovery.new(configuration)
         @started = false
       end
@@ -39,7 +40,7 @@ module Bitcoin
         port = Bitcoin.chain_params.default_port
         EM::Iterator.new(addr_list, Bitcoin::PARALLEL_THREAD).each do |ip, iter|
           if pending_peers.size < MAX_OUTBOUND_CONNECTIONS
-            peer = Peer.new(ip, port, self)
+            peer = Peer.new(ip, port, self, @configuration)
             pending_peers << peer
             peer.connect
             iter.next

--- a/lib/bitcoin/network/pool.rb
+++ b/lib/bitcoin/network/pool.rb
@@ -73,6 +73,21 @@ module Bitcoin
         peers.each { |peer| peer.broadcast_tx(tx) }
       end
 
+      # new bloom filter.
+      def filter_load(bloom)
+        peers.each { |peer| peer.send_filter_load(bloom) }
+      end
+
+      # add element to bloom filter.
+      def filter_add(element)
+        peers.each { |peer| peer.send_filter_add(element) }
+      end
+
+      # clear bloom filter.
+      def filter_clear
+        peers.each { |peer| peer.send_filter_clear }
+      end
+
       def handle_error(e)
         terminate
       end

--- a/lib/bitcoin/node/configuration.rb
+++ b/lib/bitcoin/node/configuration.rb
@@ -9,6 +9,7 @@ module Bitcoin
       def initialize(opts = {})
         # TODO apply configuration file.
         opts[:network] = :mainnet unless opts[:network]
+        opts[:relay] = false unless opts[:relay]
         Bitcoin.chain_params = opts[:network]
 
         begin

--- a/lib/bitcoin/node/spv.rb
+++ b/lib/bitcoin/node/spv.rb
@@ -17,6 +17,10 @@ module Bitcoin
         @pool = Bitcoin::Network::Pool.new(@chain, @configuration)
         @logger = Bitcoin::Logger.create(:debug)
         @running = false
+
+        # TODO : optimize bloom filter parameters
+        # TODO : load public keys in wallet.
+        @bloom = Bitcoin::BloomFilter.new(512, 0.01)
       end
 
       # open the node.
@@ -43,7 +47,22 @@ module Bitcoin
         logger.debug "broadcast tx: #{tx.to_payload.bth}"
       end
 
-    end
+      # new bloom filter.
+      def filter_load
+        pool.filter_load(@bloom)
+      end
 
+      # add filter element to bloom filter.
+      # [String] element. the hex string of txid, public key, public key hash or outpoint.
+      def filter_add(element)
+        @bloom.add(element)
+        pool.filter_add(element)
+      end
+
+      # clear bloom filter.
+      def filter_clear
+        pool.filter_clear
+      end
+    end
   end
 end

--- a/spec/bitcoin/bloom_filter_spec.rb
+++ b/spec/bitcoin/bloom_filter_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Bitcoin::BloomFilter do
+
+  # see https://github.com/bitcoin/bitcoin/blob/master/src/test/bloom_tests.cpp
+  describe '#insert' do
+    context "without tweak" do
+      subject{ Bitcoin::BloomFilter.new(3, 0.01) }
+      it do
+        subject.add("99108ad8ed9bb6274d3980bab5a85c048f0950c8".htb)
+        subject.add("b5a2c786d9ef4658287ced5914b37a1b4aa32eee".htb)
+        subject.add("b9300670b4c5366e95b2699e8b18bc75e5f729c5".htb)
+        expect(subject.to_a).to eq [0x61, 0x4e, 0x9b]
+        expect(subject.contains?("99108ad8ed9bb6274d3980bab5a85c048f0950c8".htb)).to be true
+        expect(subject.contains?("19108ad8ed9bb6274d3980bab5a85c048f0950c8".htb)).to be false
+      end
+    end
+
+    context "with tweak" do
+      subject{ Bitcoin::BloomFilter.new(3, 0.01, 2147483649) }
+      it do
+        subject.add("99108ad8ed9bb6274d3980bab5a85c048f0950c8".htb)
+        subject.add("b5a2c786d9ef4658287ced5914b37a1b4aa32eee".htb)
+        subject.add("b9300670b4c5366e95b2699e8b18bc75e5f729c5".htb)
+        expect(subject.to_a).to eq [0xce, 0x42, 0x99]
+        expect(subject.contains?("99108ad8ed9bb6274d3980bab5a85c048f0950c8".htb)).to be true
+        expect(subject.contains?("19108ad8ed9bb6274d3980bab5a85c048f0950c8".htb)).to be false
+      end
+    end
+
+    context "add key", network: :mainnet do
+      subject{ Bitcoin::BloomFilter.new(2, 0.001) }
+      it do
+        key = Bitcoin::Key.from_wif("5Kg1gnAjaLfKiwhhPpGS3QfRg2m6awQvaj98JCZBZQ5SuS2F15C")
+        subject.add(key.pubkey.htb)
+        subject.add(Bitcoin.hash160(key.pubkey).htb)
+        expect(subject.to_a).to eq [0x8f, 0xc1, 0x6b]
+      end
+    end
+  end
+
+  describe "#clear" do
+    subject{ Bitcoin::BloomFilter.new(3, 0.01) }
+    it do
+      subject.add("99108ad8ed9bb6274d3980bab5a85c048f0950c8".htb)
+      expect{subject.clear}.to change{subject.to_a}.to [0x00, 0x00, 0x00]
+      expect(subject.contains?("99108ad8ed9bb6274d3980bab5a85c048f0950c8".htb)).to be false
+    end
+  end
+end

--- a/spec/bitcoin/message/version_spec.rb
+++ b/spec/bitcoin/message/version_spec.rb
@@ -39,7 +39,8 @@ describe Bitcoin::Message::Version do
                                     timestamp: 1497706959, services: 0,
                                     version: 70015,
                                     user_agent: '/bitcoinrb:0.1.0/',
-                                    nonce: 13469974270669794112).to_pkt
+                                    nonce: 13469974270669794112,
+                                    relay: true).to_pkt
     }
     it 'should generate pkt' do
       expect(subject.bth).to eq('0b11090776657273696f6e0000000000670000000f798e7e7f1101000000000000000000cf31455900000000010000000000000000000000000000000000ffff7f000001479d010000000000000000000000000000000000ffff7f000001479d40abec703bf6eeba112f626974636f696e72623a302e312e302f00000000ff')

--- a/spec/bitcoin/network/message_handler_spec.rb
+++ b/spec/bitcoin/network/message_handler_spec.rb
@@ -10,7 +10,7 @@ describe Bitcoin::Network::MessageHandler do
       @logger = Logger.new(STDOUT)
       configuration = Bitcoin::Node::Configuration.new(network: :testnet)
       @chain = create_test_chain
-      @peer = Bitcoin::Network::Peer.new('127.0.0.1', 18332, Bitcoin::Network::Pool.new(@chain, configuration))
+      @peer = Bitcoin::Network::Peer.new('127.0.0.1', 18332, Bitcoin::Network::Pool.new(@chain, configuration), configuration)
       @sendheaders = false
     end
 

--- a/spec/bitcoin/network/peer_spec.rb
+++ b/spec/bitcoin/network/peer_spec.rb
@@ -10,7 +10,7 @@ describe Bitcoin::Network::Peer do
   subject {
     chain_mock = double('chain mock')
     configuration = Bitcoin::Node::Configuration.new(network: :testnet)
-    peer = Bitcoin::Network::Peer.new('210.196.254.100', 18333, Bitcoin::Network::Pool.new(chain, configuration))
+    peer = Bitcoin::Network::Peer.new('210.196.254.100', 18333, Bitcoin::Network::Pool.new(chain, configuration), configuration)
     peer.conn = ConnectionMock.new
     allow(peer).to receive(:chain).and_return(chain_mock)
     peer

--- a/spec/bitcoin/network/pool_spec.rb
+++ b/spec/bitcoin/network/pool_spec.rb
@@ -7,9 +7,9 @@ describe Bitcoin::Network::Pool do
     subject {
       configuration = Bitcoin::Node::Configuration.new
       pool = Bitcoin::Network::Pool.new(chain, configuration)
-      peer1 = Bitcoin::Network::Peer.new('192.168.0.1', 18333, pool)
-      peer2 = Bitcoin::Network::Peer.new('192.168.0.2', 18333, pool)
-      peer3 = Bitcoin::Network::Peer.new('192.168.0.3', 18333, pool)
+      peer1 = Bitcoin::Network::Peer.new('192.168.0.1', 18333, pool, configuration)
+      peer2 = Bitcoin::Network::Peer.new('192.168.0.2', 18333, pool, configuration)
+      peer3 = Bitcoin::Network::Peer.new('192.168.0.3', 18333, pool, configuration)
       allow(peer1).to receive(:start_block_header_download).and_return(nil)
       allow(peer2).to receive(:start_block_header_download).and_return(nil)
       allow(peer3).to receive(:start_block_header_download).and_return(nil)

--- a/spec/bitcoin/rpc/request_handler_spec.rb
+++ b/spec/bitcoin/rpc/request_handler_spec.rb
@@ -62,7 +62,7 @@ describe Bitcoin::RPC::RequestHandler do
       expect(result[0][:addr]). to eq('192.168.0.1:18333')
       expect(result[0][:addrlocal]). to eq('192.168.0.3:18333')
       expect(result[0][:services]). to eq('000000000000000c')
-      expect(result[0][:relaytxes]). to be true
+      expect(result[0][:relaytxes]). to be false
       expect(result[0][:lastsend]). to eq(1508305982)
       expect(result[0][:lastrecv]). to eq(1508305843)
       expect(result[0][:bytessent]). to eq(31298)
@@ -153,7 +153,7 @@ describe Bitcoin::RPC::RequestHandler do
     configuration = Bitcoin::Node::Configuration.new(network: :testnet)
     pool = Bitcoin::Network::Pool.new(chain, configuration)
 
-    peer1 =Bitcoin::Network::Peer.new('192.168.0.1', 18333, pool)
+    peer1 =Bitcoin::Network::Peer.new('192.168.0.1', 18333, pool, configuration)
     peer1.id = 1
     peer1.last_send = 1508305982
     peer1.last_recv = 1508305843
@@ -166,7 +166,7 @@ describe Bitcoin::RPC::RequestHandler do
     allow(peer1).to receive(:conn).and_return(conn1)
     pool.peers << peer1
 
-    peer2 =Bitcoin::Network::Peer.new('192.168.0.2', 18333, pool)
+    peer2 =Bitcoin::Network::Peer.new('192.168.0.2', 18333, pool, configuration)
     peer2.id = 2
     allow(peer2).to receive(:conn).and_return(conn2)
     pool.peers << peer2

--- a/spec/bitcoin_spec.rb
+++ b/spec/bitcoin_spec.rb
@@ -46,4 +46,15 @@ describe Bitcoin do
     end
   end
 
+  class Test
+    def initialize
+      @foo = ["bar"]
+    end
+  end
+  describe '#build_json' do
+    it 'should handle string in array' do
+      expect(["a", "b", "c"].build_json).to eq "[\"a\",\"b\",\"c\"]"
+      expect(Test.new.build_json).to eq "{\"foo\":[\"bar\"]}"
+    end
+  end
 end


### PR DESCRIPTION
spvの起動時にウォレットのアドレスを読み込んでbloom filterに追加する必要があるかと思いますが、そこは今回は実装していません。現状、アプリ側から`spv.filter_load` -> `spv.filter_add`で追加することはできます。
