### PR TITLE
Account#derive_receive(index) fails in NoMethodError.

### DIFF
--- a/lib/bitcoin/wallet/account.rb
+++ b/lib/bitcoin/wallet/account.rb
@@ -54,12 +54,12 @@ module Bitcoin
 
       # derive receive key
       def derive_receive(address_index)
-        derive_path(0, address_index)
+        derive_key(0, address_index)
       end
 
       # derive change key
       def derive_change(address_index)
-        derive_path(1, address_index)
+        derive_key(1, address_index)
       end
 
       # save this account payload to database.

--- a/lib/bitcoin/wallet/account.rb
+++ b/lib/bitcoin/wallet/account.rb
@@ -74,7 +74,7 @@ module Bitcoin
 
       # get the list of derived keys for change key.
       def derived_change_keys
-        receive_depth.times.map{|i|derive_key(1,i)}
+        change_depth.times.map{|i|derive_key(1,i)}
       end
 
       private


### PR DESCRIPTION
- A `derive_path` is not defined in Account class.

```
$ ./bin/console 
irb(main):001:0> wallet = Bitcoin::Wallet::Base.create(1, "./")
irb(main):002:0> account = wallet.accounts.first
irb(main):003:0> account.derive_receive(0)
NoMethodError (undefined method `derive_path' for #<Bitcoin::Wallet::Account:0x00007fe3268cb5e8>
Did you mean?  derive_change)
```

- #derived_change_keys returns array whose size is `receive_depth` . its size should be `change_depth` ??