### PR TITLE
Fix connection closing when receiving getdata

### DIFF
--- a/lib/bitcoin/network/connection.rb
+++ b/lib/bitcoin/network/connection.rb
@@ -50,7 +50,6 @@ module Bitcoin
       def close(msg = '')
         logger.info "close connection with #{addr}. #{msg}"
         close_connection_after_writing
-        EM.stop
       end
 
       def handle_error(e)

--- a/lib/bitcoin/network/message_handler.rb
+++ b/lib/bitcoin/network/message_handler.rb
@@ -94,6 +94,8 @@ module Bitcoin
             on_merkle_block(Bitcoin::Message::MerkleBlock.parse_from_payload(payload))
           when Bitcoin::Message::CmpctBlock::COMMAND
             on_cmpct_block(Bitcoin::Message::CmpctBlock.parse_from_payload(payload))
+          when Bitcoin::Message::GetData::COMMAND
+            on_get_data(Bitcoin::Message::GetData.parse_from_payload(payload))
           else
             logger.warn("unsupported command received. command: #{command}, payload: #{payload.bth}")
             close("with command #{command}")
@@ -230,6 +232,9 @@ module Bitcoin
         logger.info("receive cmpct_block message. #{cmpct_block.build_json}")
       end
 
+      def on_get_data(get_data)
+        logger.info("receive get data message. #{get_data.build_json}")
+      end
     end
   end
 end


### PR DESCRIPTION
When I tried to broadcast an invalid transaction through RPC request, SPV node received a get_data message from the remote peer.

I think that a receiving node(SPV node):

(1) SHOULD NOT close the connections to other peers.
(2) SHOULD ignore any get_data messages (or respond correct data to the peer).

```
I, [2018-06-11T16:09:24.078488 #26357 #70270959459780]  INFO -- : process http request. command = sendrawtransaction
I, [2018-06-11T16:09:24.084998 #26357 #70270959459780]  INFO -- : send message tx
I, [2018-06-11T16:09:24.085229 #26357 #70270959459780]  INFO -- : send message tx
I, [2018-06-11T16:09:24.085364 #26357 #70270959459780]  INFO -- : send message tx
I, [2018-06-11T16:09:24.085497 #26357 #70270959459780]  INFO -- : send message tx
I, [2018-06-11T16:09:24.245564 #26357 #70270959457780]  INFO -- : [27.151.29.86:18333] process command getdata.
W, [2018-06-11T16:09:24.250078 #26357 #70270959457780]  WARN -- : unsupported command received. command: getdata, payload: 01010000409999999999999999999999999999999999999999999999999999999999999999
I, [2018-06-11T16:09:24.250211 #26357 #70270959457780]  INFO -- : close connection with 27.151.29.86:18333. with command getdata
I, [2018-06-11T16:09:24.250365 #26357 #70270895517200]  INFO -- : unbind. 27.151.29.86:18333
I, [2018-06-11T16:09:24.257979 #26357 #70270895517200]  INFO -- : unbind. 18.236.181.225:18333
I, [2018-06-11T16:09:24.264494 #26357 #70270895517200]  INFO -- : unbind. 159.203.183.112:18333
I, [2018-06-11T16:09:24.271078 #26357 #70270895517200]  INFO -- : unbind. 35.202.163.62:18333
```
