### PR TITLE
Implement OpenAssets::Util.script_to_asset_id

### DIFF
--- a/lib/openassets.rb
+++ b/lib/openassets.rb
@@ -4,5 +4,6 @@ module OpenAssets
 
   autoload :MarkerOutput, 'openassets/marker_output'
   autoload :Payload, 'openassets/payload'
+  autoload :Util, 'openassets/util'
 
 end

--- a/lib/openassets/util.rb
+++ b/lib/openassets/util.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module OpenAssets
+  module Util
+    class << self
+      OA_VERSION_BYTE = '17' # 0x23
+      OA_VERSION_BYTE_TESTNET = '73' # 0x115
+
+      def script_to_asset_id(script)
+        hash_to_asset_id(Bitcoin.hash160(script))
+      end
+
+      private
+
+      def hash_to_asset_id(hash)
+        hash = oa_version_byte + hash
+        Bitcoin::Base58.encode(hash + Bitcoin.calc_checksum(hash))
+      end
+
+      def oa_version_byte
+        case Bitcoin.chain_params.network
+        when 'mainnet' then OA_VERSION_BYTE
+        when 'testnet', 'regtest' then OA_VERSION_BYTE_TESTNET
+        end
+      end
+    end
+  end
+end

--- a/spec/openassets/util_spec.rb
+++ b/spec/openassets/util_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe OpenAssets::Util do
+  describe  '.script_to_asset_id' do
+    before { Bitcoin.chain_params = chain }
+
+    context 'mainnet' do
+      let(:chain) { :mainnet }
+
+      it 'script_to_asset_id' do
+        # OP_DUP OP_HASH160 010966776006953d5567439e5e39f86a0d273bee OP_EQUALVERIFY OP_CHECKSIG
+        expect(described_class.script_to_asset_id('76a914010966776006953d5567439e5e39f86a0d273bee88ac')).to eq('ALn3aK1fSuG27N96UGYB1kUYUpGKRhBuBC')
+      end
+    end
+
+    context 'testnet' do
+      let(:chain) { :testnet }
+
+      it 'script_to_asset_id' do
+        # OP_HASH160 f9d499817e88ef7b10a88673296c6d6df2f4292d OP_EQUAL
+        expect(described_class.script_to_asset_id('a914f9d499817e88ef7b10a88673296c6d6df2f4292d87')).to eq('oMb2yzA542yQgwn8XtmGefTzBv5NJ2nDjh')
+      end
+    end
+
+    context 'regtest' do
+      let(:chain) { :regtest }
+
+      it 'script_to_asset_id' do
+        # OP_HASH160 f9d499817e88ef7b10a88673296c6d6df2f4292d OP_EQUAL
+        expect(described_class.script_to_asset_id('a914f9d499817e88ef7b10a88673296c6d6df2f4292d87')).to eq('oMb2yzA542yQgwn8XtmGefTzBv5NJ2nDjh')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is ported from openassets-ruby.
