### PR TITLE
Merkleblock

### DIFF
--- a/lib/bitcoin/merkle_tree.rb
+++ b/lib/bitcoin/merkle_tree.rb
@@ -120,7 +120,7 @@ module Bitcoin
       # @return node which has same hash as target. nil if this node and any children don't have same hash.
       def find_node(target)
         return self if hash == target
-        return nil if flag.zero?
+        return nil if flag && flag.zero?
         return left&.find_node(target) || right&.find_node(target)
       end
 

--- a/lib/bitcoin/merkle_tree.rb
+++ b/lib/bitcoin/merkle_tree.rb
@@ -52,6 +52,10 @@ module Bitcoin
       nodes.first
     end
 
+    def find_node(hash)
+      root.find_node(hash)
+    end
+
     # node of merkle tree
     class Node
 
@@ -112,7 +116,25 @@ module Bitcoin
         d
       end
 
+      # @param target hash to be found
+      # @return node which has same hash as target. nil if this node and any children don't have same hash.
+      def find_node(target)
+        return self if hash == target
+        return nil if flag.zero?
+        return left&.find_node(target) || right&.find_node(target)
+      end
+
+      def index
+        i = 0
+        d = 1
+        current_node = self
+        until current_node.root? do
+          i += d if current_node.parent.right == current_node
+          current_node = current_node.parent
+          d *= 2
+        end
+        i
+      end
     end
   end
-
 end

--- a/lib/bitcoin/network/message_handler.rb
+++ b/lib/bitcoin/network/message_handler.rb
@@ -226,6 +226,7 @@ module Bitcoin
 
       def on_merkle_block(merkle_block)
         logger.info("receive merkle block message. #{merkle_block.build_json}")
+        peer.handle_merkle_block(merkle_block)
       end
 
       def on_cmpct_block(cmpct_block)

--- a/lib/bitcoin/network/peer.rb
+++ b/lib/bitcoin/network/peer.rb
@@ -190,6 +190,11 @@ module Bitcoin
         pool.notify_observers(:tx, tx)
       end
 
+      def handle_merkle_block(merkle_block)
+        pool.changed
+        pool.notify_observers(:merkleblock, merkle_block)
+      end
+
       # send ping message.
       def send_ping
         ping = Bitcoin::Message::Ping.new

--- a/spec/bitcoin/merkle_tree_spec.rb
+++ b/spec/bitcoin/merkle_tree_spec.rb
@@ -159,5 +159,55 @@ describe Bitcoin::MerkleTree do
         expect(subject).to be_nil
       end
     end
+
+    context 'tree is built by using #build_from_leaf' do
+      let(:tree) do
+        tx_hashes = ['df98e4366c58c98506f4eb5eadbf1c4c73f60c2d2c00e2d3f6260aa4dc780627',
+                 '2f2786c7683cf35932da2c90d541aa608f2844cd3d5a4aa524c13dcc97567922',
+                 '1ffe110ce6ab3ba01ca15058f602db64beb31ddb8cf3bf2b0230058ccce3de25',
+                 '649f439bbda9a4208307646d284045e2e2fb49a114be4d23ae1804ddf6efb39f',
+                 '7916ca0ff3c6802471e0e9640abe80c61ac72d9c849218c45a62920779b43cbe',
+                 'c5470b3427ef2894b5741c7665483711a783f1e69e2570755b633f982882b613',
+                 '0148598705017478c41dc43417f9ffe4001688ea095fe0f22e0c8a6686c377b8',
+                 '03bd93facda172f836ad9766903494870a1dc2fec2f818d8d769155682334559',
+                 '6543da80cf7bfc38efb6c489b8f481a867007725f56f7606dd7f1c0368e193a0',
+                 'b657c9263323bcd599f46158d4d53a10f0f031642d6259731cea9aaaf53388ce',
+                 'bcb41cd50ace70e0ac375bb987645c515a2ebdf4cebfcfc95b677cb75671150c',
+                 '75d9acf06331809ae226c6f148e2158fe3bcfe67adce7380de17050ba4be8509',
+                 '1903061dbf9baa52d2ec55fb28457dcf82823ed78f0c85fe8e4e9133e65901be',
+                 '1d39400b286d22922e84f6798de74f53a45837e59c339fb126a5c8bcb18008f4',
+                 '6befa1ce31127ba008e5b988f469217b2e2fa3669c6be735c64c970741e5cdef',
+                 'acbf66e735ed7044786c842710166b367c3ba19f75bcdb2cde43035f50f9087f',
+                 'b4bea4398960cada331b48e110b882e39f606a543fb4266d15dc91dbba26abb1',
+                 'dc9cee940b2cec0dbfb2e0b9733dc544c1296b5bcf800530cbac28f6fecc62b4',
+                 '9f604dcdbb0c6bb1c5e04e70a2cd9e7c085eb6804493a815390092d0e50c0e50',
+                 '69fcd16197f9214412f01edfe093105500e78f86746eaf25b5fde185dab5ec00',
+                 '9db475abeb0b364a7d9d98702f30def5b801d9ea13bc391a80b6e72258ac3200',
+                 '9e15621ec0ce1c65787fb18190ba95cd98761650915222a273b79c3021c58301',
+                 'adebbe346b10139a29319788fd8f34bfdf830143ca6e0f58ffee1125d7b75801',
+                 '114c0efb38c701e7f9f440eea02ae51a73b4b5f28de5935dbc9a893ae4c31b00',
+                 '1f3adf2e837d46caf125e5470ec2efdb670ef4667666867bb4af94a7e1874901',
+                 '4e7afff20d08febec9082c72d084d47a671fe95db3f94a8b5aa7652853e6f800',
+                 '073cdf832de79004f233dedfe07282cf6c6675b0f680fe5dc370d7d3dd1bc025',
+                 'f83d60e1d2fb2a4451f680f255435491af5925c64f2d4ee53d2d999fc30f4dc8',
+                 '8fad253105dbf3cfc7bfc419fe9a0ae9b79202be80c90de8cd4e8015d58fa1ed',
+                 '3334ee35d5601a014b1bed68ed620eb16d4453e5182b9dd5784c39193fcc2370',
+                 '635fd78620a92711b44cb7ee489b46e6f15f4e5bdafd7fa57d753168e698b082',
+                 'bbc9523348bfeb97cda11d2d20428726f42bcceba1d01c9d6df4bd77fa387f0e',
+                 '6084c3a4d9d2063587c89a5cbd3418e6f73b2c1047e8609f384fb9f5f35fe54a',
+                 '41ef68a8967c7962624e153ee2a06d3f01716aa0ae16d2a1e6ec65cee8ea3ca6',
+                 '27686773cac3642558b12897d3081a7c7a3709202cc3534db57be02d9dc68559',
+                 '20a6587b441793253a44e13fcb053ef6eb8aaa855c2a39fa38cb732eaf5d84e8',
+                 'd2f9b2a4abbd29464eccedf319f4d1eb6a3bfb28002f8e2a12340fec4639f9b4']
+        Bitcoin::MerkleTree.build_from_leaf(tx_hashes)
+      end
+
+      subject { tree.find_node('75d9acf06331809ae226c6f148e2158fe3bcfe67adce7380de17050ba4be8509') }
+      it 'should return leaf node' do
+        expect(subject.leaf?).to be_truthy
+        expect(subject.index).to eq 11
+        expect(subject.depth).to eq 6
+      end
+    end
   end
 end

--- a/spec/bitcoin/merkle_tree_spec.rb
+++ b/spec/bitcoin/merkle_tree_spec.rb
@@ -73,7 +73,30 @@ describe Bitcoin::MerkleTree do
         expect(subject.merkle_root).to eq('7f16c5962e8bd963659c793ce370d95f093bc7e367117b3c30c1f8fdd0d97287')
       end
     end
-
   end
 
+  describe 'find_node' do
+    let(:tree) do
+      hashes = ['3612262624047ee87660be1a707519a443b1c1ce3d248cbfc6c15870f6c5daa2',
+                '019f5b01d4195ecbc9398fbf3c3b1fa9bb3183301d7a1fb3bd174fcfa40a2b65',
+                '41ed70551dd7e841883ab8f0b16bf04176b7d1480e4f0af9f3d4c3595768d068',
+                '20d2a7bc994987302e5b1ac80fc425fe25f8b63169ea78e68fbaaefa59379bbf']
+      Bitcoin::MerkleTree.build_partial(7, hashes, Bitcoin.byte_to_bit('1d'.htb))
+    end
+
+    context 'hash is in tree' do
+      subject { tree.find_node('019f5b01d4195ecbc9398fbf3c3b1fa9bb3183301d7a1fb3bd174fcfa40a2b65') }
+      it 'should return node' do
+        expect(subject.leaf?).to be_truthy
+        expect(subject.index).to eq 4
+      end
+    end
+
+    context 'hash is not in tree' do
+      subject { tree.find_node('0000000000000000000000000000000000000000000000000000000000000000') }
+      it 'should return nil' do
+        expect(subject).to be_nil
+      end
+    end
+  end
 end

--- a/spec/bitcoin/merkle_tree_spec.rb
+++ b/spec/bitcoin/merkle_tree_spec.rb
@@ -77,6 +77,10 @@ describe Bitcoin::MerkleTree do
 
   describe 'find_node' do
     let(:tree) do
+      # H1 = 3612262624047ee87660be1a707519a443b1c1ce3d248cbfc6c15870f6c5daa2
+      # H2 = 019f5b01d4195ecbc9398fbf3c3b1fa9bb3183301d7a1fb3bd174fcfa40a2b65
+      # H3 = 41ed70551dd7e841883ab8f0b16bf04176b7d1480e4f0af9f3d4c3595768d068
+      # H4 = 20d2a7bc994987302e5b1ac80fc425fe25f8b63169ea78e68fbaaefa59379bbf
       hashes = ['3612262624047ee87660be1a707519a443b1c1ce3d248cbfc6c15870f6c5daa2',
                 '019f5b01d4195ecbc9398fbf3c3b1fa9bb3183301d7a1fb3bd174fcfa40a2b65',
                 '41ed70551dd7e841883ab8f0b16bf04176b7d1480e4f0af9f3d4c3595768d068',
@@ -84,11 +88,68 @@ describe Bitcoin::MerkleTree do
       Bitcoin::MerkleTree.build_partial(7, hashes, Bitcoin.byte_to_bit('1d'.htb))
     end
 
-    context 'hash is in tree' do
+    context 'hash is merkle root' do
+      subject { tree.find_node('7f16c5962e8bd963659c793ce370d95f093bc7e367117b3c30c1f8fdd0d97287') }
+      it 'should return root node' do
+        expect(subject.leaf?).to be_falsy
+        expect(subject.index).to eq 0
+        expect(subject.depth).to eq 0
+      end
+    end
+
+    context 'inner node has hash H1' do
+      subject { tree.find_node('3612262624047ee87660be1a707519a443b1c1ce3d248cbfc6c15870f6c5daa2') }
+      it 'should return inner node' do
+        expect(subject.leaf?).to be_falsy
+        expect(subject.index).to eq 0
+        expect(subject.depth).to eq 1
+      end
+    end
+
+    context 'leaf node has hash H2' do
       subject { tree.find_node('019f5b01d4195ecbc9398fbf3c3b1fa9bb3183301d7a1fb3bd174fcfa40a2b65') }
-      it 'should return node' do
+      it 'should return leaf node' do
         expect(subject.leaf?).to be_truthy
         expect(subject.index).to eq 4
+        expect(subject.depth).to eq 3
+      end
+    end
+
+    context 'leaf node has hash H3' do
+      subject { tree.find_node('41ed70551dd7e841883ab8f0b16bf04176b7d1480e4f0af9f3d4c3595768d068') }
+      it 'should return inner node' do
+        expect(subject.leaf?).to be_truthy
+        expect(subject.index).to eq 5
+        expect(subject.depth).to eq 3
+      end
+    end
+
+    context 'inner node has hash d(H2 + H3)' do
+      # double hash of (019f5b01d4195ecbc9398fbf3c3b1fa9bb3183301d7a1fb3bd174fcfa40a2b65 || 41ed70551dd7e841883ab8f0b16bf04176b7d1480e4f0af9f3d4c3595768d068)
+      subject { tree.find_node('323a54ad9aa4ba42d1edfb9519af995cf93b736364f81a090885b61b6d7ee1ca') }
+      it 'should return inner node' do
+        expect(subject.leaf?).to be_falsy
+        expect(subject.index).to eq 2
+        expect(subject.depth).to eq 2
+      end
+    end
+
+    context 'inner node has hash H4' do
+      subject { tree.find_node('20d2a7bc994987302e5b1ac80fc425fe25f8b63169ea78e68fbaaefa59379bbf') }
+      it 'should return inner node' do
+        expect(subject.leaf?).to be_falsy
+        expect(subject.index).to eq 3
+        expect(subject.depth).to eq 2
+      end
+    end
+
+    context 'inner node has hash d(d(H2 + H3) + H4)' do
+      # double hash of (323a54ad9aa4ba42d1edfb9519af995cf93b736364f81a090885b61b6d7ee1ca || 20d2a7bc994987302e5b1ac80fc425fe25f8b63169ea78e68fbaaefa59379bbf)
+      subject { tree.find_node('cfbc39264b50034b71abba2d4eb0220ad66bf8ffde47d42b32b199accbdca739') }
+      it 'should return inner node' do
+        expect(subject.leaf?).to be_falsy
+        expect(subject.index).to eq 1
+        expect(subject.depth).to eq 1
       end
     end
 

--- a/spec/bitcoin/network/peer_spec.rb
+++ b/spec/bitcoin/network/peer_spec.rb
@@ -132,4 +132,19 @@ describe Bitcoin::Network::Peer do
       subject.handle_tx(tx)
     end
   end
+
+  describe '#handler_merkle_block' do
+    it 'should call update with :merkleblock' do
+      listener = double('listener')
+      payload = "0100000082bb869cf3a793432a66e826e05a6fc37469f8efb7421dc880670100000000007f16c5962e8bd963659c793ce370d95f093bc7e367117b3c30c1f8fdd0d9728776381b4d4c86041b554b852907000000043612262624047ee87660be1a707519a443b1c1ce3d248cbfc6c15870f6c5daa2019f5b01d4195ecbc9398fbf3c3b1fa9bb3183301d7a1fb3bd174fcfa40a2b6541ed70551dd7e841883ab8f0b16bf04176b7d1480e4f0af9f3d4c3595768d06820d2a7bc994987302e5b1ac80fc425fe25f8b63169ea78e68fbaaefa59379bbf011d".htb
+      merkle_block = Bitcoin::Message::MerkleBlock.parse_from_payload(payload)
+      expect(listener).to receive(:update).with(:merkleblock, merkle_block)
+      subject.pool.add_observer(listener)
+      subject.handle_merkle_block(merkle_block)
+
+      subject.pool.delete_observer(listener)
+      expect(listener).not_to receive(:update)
+      subject.handle_merkle_block(merkle_block)
+    end
+  end
 end


### PR DESCRIPTION
This PR implements 

1.  notification to observers when the spv node is received `merkleblock` message from the peer.
2. methods for calculating the transaction index within the block.

Calculating the index is required for Lightning Network 
(see `short_channel_id` description in https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#requirements)
