### PR TITLE
Fix error in MerkleTree::Node#value (#28)

### DIFF
--- a/lib/bitcoin/merkle_tree.rb
+++ b/lib/bitcoin/merkle_tree.rb
@@ -35,7 +35,12 @@ module Bitcoin
           hash_index += 1
         end
         current_node = current_node.next_partial
-        break if hash_index == hashes.size
+        if hash_index == hashes.size
+          if current_node&.leaf?
+            current_node.value = hashes.last
+          end
+          break
+        end
       end
       new(root)
     end

--- a/spec/bitcoin/merkle_tree_spec.rb
+++ b/spec/bitcoin/merkle_tree_spec.rb
@@ -160,6 +160,20 @@ describe Bitcoin::MerkleTree do
       end
     end
 
+    context 'find final txid in tree which has odd number of txids' do
+      let(:tree) do
+        hashes = ["eabc5a0f2db047073fd8bcc8317b72578f705a0845b33d3c0fa939421219a452", "15157a0138efe2d76ca0ef26f4b42341bd14ff2871603e7364a1d404da51493f"]
+        Bitcoin::MerkleTree.build_partial(3, hashes, Bitcoin.byte_to_bit('1d'.htb))
+      end
+
+      subject { tree.find_node('15157a0138efe2d76ca0ef26f4b42341bd14ff2871603e7364a1d404da51493f') }
+      it 'should return nil' do
+        expect(subject.leaf?).to be_truthy
+        expect(subject.index).to eq 2
+        expect(subject.depth).to eq 2
+      end
+    end
+
     context 'tree is built by using #build_from_leaf' do
       let(:tree) do
         tx_hashes = ['df98e4366c58c98506f4eb5eadbf1c4c73f60c2d2c00e2d3f6260aa4dc780627',


### PR DESCRIPTION
Fix error in MerkleTree::Node#value for nodes in the tree which has an odd number of txids(#28)

* The leaf created by copying last txid leaf should have same value as source leaf